### PR TITLE
Adds the ability to run a specific type of scenario multiple times

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,16 +1,19 @@
 kraken:
     kubeconfig_path: /root/.kube/config                    # Path to kubeconfig
     exit_on_failure: False                                 # Exit when a post action scenario fails
-    scenarios:                                             # List of policies/chaos scenarios to load
-        - -    scenarios/etcd.yml
-        - -    scenarios/openshift-kube-apiserver.yml
-        - -    scenarios/openshift-apiserver.yml
-        - -    scenarios/regex_openshift_pod_kill.yml
-          -    scenarios/post_action_regex.py
-    node_scenarios:                                        # List of chaos node scenarios to load
-        -   scenarios/node_scenarios_example.yml
-    time_scenarios:                                        # List of chaos time scenarios to load
-        - scenarios/time_scenarios_example.yml
+    chaos_scenarios:                                         # List of policies/chaos scenarios to load
+        -   pod_scenarios:                                 # List of chaos pod scenarios to load
+            - -    scenarios/etcd.yml
+            - -    scenarios/regex_openshift_pod_kill.yml
+              -    scenarios/post_action_regex.py
+        -   node_scenarios:                                # List of chaos node scenarios to load
+            -   scenarios/node_scenarios_example.yml
+        -   pod_scenarios:
+            - -    scenarios/openshift-apiserver.yml
+            - -    scenarios/openshift-kube-apiserver.yml
+        -   time_scenarios:                                # List of chaos time scenarios to load
+            - scenarios/time_scenarios_example.yml
+
 cerberus:
     cerberus_enabled: False                                # Enable it when cerberus is previously installed
     cerberus_url:                                          # When cerberus_enabled is set to True, provide the url where cerberus publishes go/no-go signal

--- a/docs/config.md
+++ b/docs/config.md
@@ -4,12 +4,19 @@ Set the scenarios to inject and the tunings like duration to wait between each s
 ```
 kraken:
     kubeconfig_path: /root/.kube/config                    # Path to kubeconfig
-    scenarios:                                             # List of policies/chaos scenarios to load
-        -    scenarios/etcd.yml
-        -    scenarios/openshift-kube-apiserver.yml
-        -    scenarios/openshift-apiserver.yml
-    node_scenarios:                                        # List of chaos node scenarios to load
-        -    scenarios/node_scenarios_example.yml
+    exit_on_failure: False                                 # Exit when a post action scenario fails
+    chaos_scenarios:                                         # List of policies/chaos scenarios to load
+        -   pod_scenarios:                                 # List of chaos pod scenarios to load
+            - -    scenarios/etcd.yml
+            - -    scenarios/regex_openshift_pod_kill.yml
+              -    scenarios/post_action_regex.py
+        -   node_scenarios:                                # List of chaos node scenarios to load
+            -   scenarios/node_scenarios_example.yml
+        -   pod_scenarios:
+            - -    scenarios/openshift-apiserver.yml
+            - -    scenarios/openshift-kube-apiserver.yml
+        -   time_scenarios:                                # List of chaos time scenarios to load
+            - scenarios/time_scenarios_example.yml
 
 cerberus:
     cerberus_enabled: False                                # Enable it when cerberus is previously installed
@@ -19,3 +26,4 @@ tunings:
     wait_duration: 60                                      # Duration to wait between each chaos scenario
     iterations: 1                                          # Number of times to execute the scenarios
     daemon_mode: False                                     # Iterations are set to infinity which means that the kraken will cause chaos forever
+```


### PR DESCRIPTION
With the current implementation, all the scenarios of specific type
(for example, pod scenario) has to be executed together. All
pod_scenarios are followed by node_scenarios and so on.
(pod_scenarios -> node_scenarios -> pod_scenarios is not possible)
This commit enables the user to run a specific type of scenario
multiple times. For example, few pod_scenarios followed by
node_scenarios followed by few pod_scenarios.