### PR TITLE
Display the pod scenarios logs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ dist: xenial
 
 langauge: python
 
-python: "3.6"
+python: "3.6.8"
 
 before_install:
   - sudo apt-get update

--- a/run_kraken.py
+++ b/run_kraken.py
@@ -160,10 +160,13 @@ def pod_scenarios(scenarios_list, config, failed_post_scenarios):
                 pre_action_output = run_post_action(kubeconfig_path, pod_scenario[1])
             else:
                 pre_action_output = ''
-            runcommand.invoke("powerfulseal autonomous --use-pod-delete-instead-of-ssh-kill"
+            scenario_logs = runcommand.invoke("powerfulseal autonomous --use-pod-delete-instead-of-ssh-kill"
                               " --policy-file %s --kubeconfig %s --no-cloud"
                               " --inventory-kubernetes --headless"
                               % (pod_scenario[0], kubeconfig_path))
+
+            # Display pod scenario logs/actions
+            print(scenario_logs)
 
             logging.info("Scenario: %s has been successfully injected!" % (pod_scenario[0]))
             logging.info("Waiting for the specified duration: %s" % (wait_duration))


### PR DESCRIPTION
The current implementation just reports the pass/fail when
running the pod scenarios. This commit prints the pod scenarios logs
to stdout to give users the ability to understand the actions run by
powerfulseal under the hood - number of pods matching the filter,
pods picked for killing, post checks etc. This also helps in
debugging when the scenarios fail.